### PR TITLE
FSPROD 1295 clearing the value of category filter will fetch the all …

### DIFF
--- a/src/Components/GuestUser/GuestUserDatasets.js
+++ b/src/Components/GuestUser/GuestUserDatasets.js
@@ -230,6 +230,8 @@ export default function GuestUserDatasets(props) {
           setSubcategoryFilterValue([]);
           break;
       }
+      // Reset dataset list to the original state if the category filter is empty
+      if (value.length === 0) getAllDataSets();
     } else if (input_field === "Subcategories") {
       setSubcategoryFilterValue(value);
     }


### PR DESCRIPTION
Ticker Detail : FSPROD 1295 
Issue : On clearing the category filter all dataset fetching was not working
Solution : If the value of the filter is empty it will fetch the all data by calling a simple func getAllDataset

